### PR TITLE
Implement V2 Progress Bar

### DIFF
--- a/src/progress_bar_exercise/Button.js
+++ b/src/progress_bar_exercise/Button.js
@@ -4,15 +4,17 @@ import PropTypes from "prop-types";
 // Button component.
 const Button = ({
   color,
+  disabled,
   label,
   onClick,
 }) => {
   return (
     <button
-      className="button"
+      className={`button ${disabled ? "disabled" : ""}`}
       onClick={onClick}
       type="button"
       style={{color: `${color}`}}
+      disabled={disabled}
     >
       {label}
     </button>
@@ -23,6 +25,9 @@ Button.propTypes = {
   /** Color of button. Must be in proper color notation. */
   color: PropTypes.string,
 
+  /** Determines if button is clickable. */
+  disabled: PropTypes.bool,
+
   /** Label for button. Defaults to "Click". */
   label: PropTypes.string,
 
@@ -32,6 +37,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   color: "black",
+  disabled: false,
   label: "Click",
   onClick: () => {},
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -23,7 +23,7 @@ const Solution = () => {
   // Variables
   const interval = 1000;
   const finishInterval = 100;
-  const breakpoints = [30, 32, 82];
+  const breakpoints = [10, 30, 32, 82];
 
   // State
   const [percentage, setPercentage] = useState(0);
@@ -33,6 +33,7 @@ const Solution = () => {
   const [finishTimer, setFinishTimer] = useState();
   const [isStarted, setIsStarted] = useState(false);
   const [isFinished, setIsFinished] = useState(false);
+  const [isUsingBreakpoints, setIsUsingBreakpoints] = useState(false);
 
   // Effects
 
@@ -84,16 +85,16 @@ const Solution = () => {
 
     const timerId = window.setInterval(() => {
       setPercentage((prevPercentage) => {
-        let newPercentage;
+        if (isUsingBreakpoints === true) {
+          for (let i = 0; i < breakpoints.length; i++) {
+            const breakpoint = breakpoints[i];
+            if (breakpoint - 3 <= prevPercentage && prevPercentage <= breakpoint + 3) {
+              if (prevPercentage + 1 > 90) {
+                return 90;
+              }
 
-        for (let i = 0; i < breakpoints.length; i++) {
-          const breakpoint = breakpoints[i];
-          if (breakpoint - 3 <= prevPercentage && prevPercentage <= breakpoint + 3) {
-            if (prevPercentage + 1 > 90) {
-              return 90;
+              return prevPercentage + 2;
             }
-
-            return prevPercentage + 2;
           }
         }
 
@@ -136,11 +137,26 @@ const Solution = () => {
     }
   };
 
+  /**
+   * Switch between a progress bar that uses breakpoints and one that
+   * does not use breakpoints.
+   */
+  const handleToggleClick = () => {
+    setIsUsingBreakpoints(!isUsingBreakpoints);
+  };
+
   return (
     <React.Fragment>
+      <p>{percentage}</p>
       <ProgressBar perc={percentage} isFinished={isFinished} />
-      <Button label={isStarted ? "Loading..." : "Start Request"} color="green" onClick={handleStartClick} />
-      <Button label="Finish Request" color="red" onClick={handleFinishClick} />
+      <div>
+        <Button label={isStarted ? "Loading..." : "Start Request"} color="green" onClick={handleStartClick} />
+        <Button label="Finish Request" color="red" onClick={handleFinishClick} />
+      </div>
+      <div>
+        <Button label={"Toggle"} onClick={handleToggleClick} />
+        <p>{isUsingBreakpoints ? "Using Breakpoints" : "Not Using Breakpoints"}</p>
+      </div>
     </React.Fragment>
   );
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -147,14 +147,13 @@ const Solution = () => {
 
   return (
     <React.Fragment>
-      <p>{percentage}</p>
       <ProgressBar perc={percentage} isFinished={isFinished} />
       <div>
-        <Button label={isStarted ? "Loading..." : "Start Request"} color="green" onClick={handleStartClick} />
+        <Button label={isStarted ? "Loading..." : "Start Request"} color="green" onClick={handleStartClick}/>
         <Button label="Finish Request" color="red" onClick={handleFinishClick} />
       </div>
       <div>
-        <Button label={"Toggle"} onClick={handleToggleClick} />
+        <Button label={"Toggle"} color="grey" onClick={handleToggleClick} disabled={isStarted || isFinished}/>
         <p>{isUsingBreakpoints ? "Using Breakpoints" : "Not Using Breakpoints"}</p>
       </div>
     </React.Fragment>

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -23,6 +23,7 @@ const Solution = () => {
   // Variables
   const interval = 1000;
   const finishInterval = 100;
+  const breakpoints = [30, 32, 82];
 
   // State
   const [percentage, setPercentage] = useState(0);
@@ -48,9 +49,9 @@ const Solution = () => {
     }
   }, [timer]);
 
-  // Stop timer when it has ran for 15 seconds.
+  // Stop timer when percentage reaches 90.
   useEffect(() => {
-    if (count >= 15 && timer) {
+    if (percentage >= 90 && timer) {
       window.clearInterval(timer);
     }
   }, [count])
@@ -83,8 +84,26 @@ const Solution = () => {
 
     const timerId = window.setInterval(() => {
       setPercentage((prevPercentage) => {
-        return prevPercentage + (90 / 15);
+        let newPercentage;
+
+        for (let i = 0; i < breakpoints.length; i++) {
+          const breakpoint = breakpoints[i];
+          if (breakpoint - 3 <= prevPercentage && prevPercentage <= breakpoint + 3) {
+            if (prevPercentage + 1 > 90) {
+              return 90;
+            }
+
+            return prevPercentage + 2;
+          }
+        }
+
+        if ((prevPercentage + 90 / 15) > 90) {
+          return 90;
+        }
+
+        return prevPercentage + 90 / 15;
       });
+
       setCount((prevCount) => {
         return prevCount + 1;
       });

--- a/src/progress_bar_exercise/progress-bar-style.css
+++ b/src/progress_bar_exercise/progress-bar-style.css
@@ -23,11 +23,17 @@
   margin: 10px;
 }
 
-.button:hover {
+button:disabled,
+button[disabled] {
+  color: rgb(219, 219, 219);
+  background-color: rgb(219, 219, 219);
+}
+
+.button:hover:not([disabled]) {
   border: 2px solid;
 }
 
-.button:active {
+.button:active:not([disabled]) {
   border: 3px solid;
 }
 


### PR DESCRIPTION
**Summary**
Implement V2 progress bar component, as described in the document.

**Details**
I took an extra hour to complete V2 after completing V1. I implemented as much as I could based on the given specs.

It can now take longer than 15 seconds to reach 90%.

There are no unit tests.

**Known Issues**
User can only toggle between progress bars at start of app, before pressing either the "Start" or "Finish" button.

**Remaining Questions**
* It was not clear exactly how to implement the slowness. In my implementation, I just added a buffer to each number in the breakpoints array, and if the current percentage is within that buffer, then I slow down the animation (by incrementing the progress bar by 2% instead of the usual 6%). Normally in a work environment, I would seek out clarification before implementing based on assumptions.
* The toggle method was also unclear, so I just added another button to toggle between progress bars. I also made it so the user can only toggle at the beginning, before clicking either "Start" or "Finish".